### PR TITLE
Limit Number of default routes returned to 1

### DIFF
--- a/vpnsetup.sh
+++ b/vpnsetup.sh
@@ -69,7 +69,7 @@ if [ "$(id -u)" != 0 ]; then
   exiterr "Script must be run as root. Try 'sudo sh $0'"
 fi
 
-def_iface=$(route 2>/dev/null | grep '^default' | grep -o '[^ ]*$')
+def_iface=$(route 2>/dev/null | grep -m 1 '^default' | grep -o '[^ ]*$')
 [ -z "$def_iface" ] && def_iface=$(ip -4 route list 0/0 2>/dev/null | grep -Po '(?<=dev )(\S+)')
 def_state=$(cat "/sys/class/net/$def_iface/operstate" 2>/dev/null)
 if [ -n "$def_state" ] && [ "$def_state" != "down" ]; then


### PR DESCRIPTION
I was installing on a VM running Ubuntu 18.04 on Oracle Cloud and I kept getting the error `Could not detect the default network interface.`. Then I decided to check my routes and noticed I have 2 `default` destinations by default.

```
ubuntu@instance-20190308-0900:~$ route
Kernel IP routing table
Destination     Gateway         Genmask         Flags Metric Ref    Use Iface
default         _gateway        0.0.0.0         UG    0      0        0 ens3
default         _gateway        0.0.0.0         UG    100    0        0 ens3
10.0.0.0        0.0.0.0         255.255.255.0   U     0      0        0 ens3
link-local      0.0.0.0         255.255.0.0     U     100    0        0 ens3
```

To fix it, I added the option `-m 1` to the grep checking for default routes to limit the returned result to 1.